### PR TITLE
[modules] New covid tracker module

### DIFF
--- a/app/widget_maker.go
+++ b/app/widget_maker.go
@@ -12,6 +12,7 @@ import (
 	cdsstatus "github.com/wtfutil/wtf/modules/cds/status"
 	"github.com/wtfutil/wtf/modules/circleci"
 	"github.com/wtfutil/wtf/modules/clocks"
+	"github.com/wtfutil/wtf/modules/covid"
 	"github.com/wtfutil/wtf/modules/cmdrunner"
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/bittrex"
 	"github.com/wtfutil/wtf/modules/cryptoexchanges/blockfolio"
@@ -137,6 +138,9 @@ func MakeWidget(
 	case "clocks":
 		settings := clocks.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = clocks.NewWidget(app, settings)
+	case "covid":
+		settings := covid.NewSettingsFromYAML(moduleName, moduleConfig, config)
+		widget = covid.NewWidget(app, settings)
 	case "cmdrunner":
 		settings := cmdrunner.NewSettingsFromYAML(moduleName, moduleConfig, config)
 		widget = cmdrunner.NewWidget(app, settings)

--- a/modules/covid/cases.go
+++ b/modules/covid/cases.go
@@ -5,7 +5,7 @@ type Cases struct {
 	Latest Latest `json:"latest"`
 }
 
-// Latest holds the number of global confirmed, recovered cases and deaths due to Covid
+// Latest holds the number of global confirmed cases and deaths due to Covid
 type Latest struct {
 	Confirmed int `json:"confirmed"`
 	Deaths    int `json:"deaths"`

--- a/modules/covid/cases.go
+++ b/modules/covid/cases.go
@@ -5,9 +5,22 @@ type Cases struct {
 	Latest Latest `json:"latest"`
 }
 
-// Latest holds the number of confirmed, recovered cases and deaths due to Covid
+// Latest holds the number of global confirmed, recovered cases and deaths due to Covid
 type Latest struct {
 	Confirmed int `json:"confirmed"`
 	Deaths    int `json:"deaths"`
 	Recovered int `json:"recovered"`
+}
+
+// CountryCases holds the latest cases for a given country
+type CountryCases struct {
+	LatestCountryCases LatestCountryCases `json:"latest"`
+}
+
+// LatestCountryCases holds the number of confirmed, recovered cases and deaths due to Covid for a given country
+type LatestCountryCases struct {
+	Confirmed int                    `json:"confirmed"`
+	Deaths    int                    `json:"deaths"`
+	Recovered int                    `json:"recovered"`
+	Locations map[string]interface{} `json:"locations,omitempty"`
 }

--- a/modules/covid/cases.go
+++ b/modules/covid/cases.go
@@ -9,7 +9,6 @@ type Cases struct {
 type Latest struct {
 	Confirmed int `json:"confirmed"`
 	Deaths    int `json:"deaths"`
-	Recovered int `json:"recovered"`
 }
 
 // CountryCases holds the latest cases for a given country
@@ -21,6 +20,5 @@ type CountryCases struct {
 type LatestCountryCases struct {
 	Confirmed int                    `json:"confirmed"`
 	Deaths    int                    `json:"deaths"`
-	Recovered int                    `json:"recovered"`
 	Locations map[string]interface{} `json:"locations,omitempty"`
 }

--- a/modules/covid/cases.go
+++ b/modules/covid/cases.go
@@ -9,4 +9,6 @@ type Cases struct {
 type Latest struct {
 	Confirmed int `json:"confirmed"`
 	Deaths    int `json:"deaths"`
+	// Not currently used but holds information about the country
+	Locations []interface{} `json:"locations,omitempty"`
 }

--- a/modules/covid/cases.go
+++ b/modules/covid/cases.go
@@ -10,15 +10,3 @@ type Latest struct {
 	Confirmed int `json:"confirmed"`
 	Deaths    int `json:"deaths"`
 }
-
-// CountryCases holds the latest cases for a given country
-type CountryCases struct {
-	LatestCountryCases LatestCountryCases `json:"latest"`
-}
-
-// LatestCountryCases holds the number of confirmed, recovered cases and deaths due to Covid for a given country
-type LatestCountryCases struct {
-	Confirmed int                    `json:"confirmed"`
-	Deaths    int                    `json:"deaths"`
-	Locations map[string]interface{} `json:"locations,omitempty"`
-}

--- a/modules/covid/cases.go
+++ b/modules/covid/cases.go
@@ -1,0 +1,13 @@
+package covid
+
+// Cases holds the latest cases
+type Cases struct {
+	Latest Latest `json:"latest"`
+}
+
+// Latest holds the number of confirmed, recovered cases and deaths due to Covid
+type Latest struct {
+	Confirmed int `json:"confirmed"`
+	Deaths    int `json:"deaths"`
+	Recovered int `json:"recovered"`
+}

--- a/modules/covid/client.go
+++ b/modules/covid/client.go
@@ -31,9 +31,9 @@ func LatestCases() (*Cases, error) {
 }
 
 // LatestCountryCases queries the /locations endpoint, takes a query parameter: the country code
-func (widget *Widget) LatestCountryCases(countriesStats []interface{}) ([]*Cases, error) {
+func (widget *Widget) LatestCountryCases(countries []interface{}) ([]*Cases, error) {
 	countriesCovidData := []*Cases{}
-	for _, name := range countriesStats {
+	for _, name := range countries {
 		countryURL := covidTrackerAPIURL + "locations?source=jhu&country_code=" + name.(string)
 		resp, err := http.Get(countryURL)
 		if resp.StatusCode != 200 {

--- a/modules/covid/client.go
+++ b/modules/covid/client.go
@@ -1,0 +1,59 @@
+package covid
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/wtfutil/wtf/utils"
+)
+
+// LatestCases queries the /latest endpoint
+func LatestCases() (*Latest, error) {
+	// TODO: figure out the pointer logic here
+	latest := &Latest{}
+
+	resp, err := covidAPIRequest("latest")
+	if err != nil {
+		// TODO: figure out the pointer logic here
+		return latest, err
+	}
+
+	err = utils.ParseJSON(&latest, resp.Body)
+	if err != nil {
+		// TODO: figure out the pointer logic here
+		return latest, err
+	}
+	// TODO: figure out the pointer logic here
+	return latest, nil
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+var (
+	covidTrackerAPIURL = &url.URL{Scheme: "https", Host: "coronavirus-tracker-api.herokuapp.com", Path: "/v2/"}
+)
+
+func covidAPIRequest(path string) (*http.Response, error) {
+	uri := covidTrackerAPIURL.ResolveReference(&url.URL{Path: path})
+
+	req, err := http.NewRequest("GET", uri.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf(resp.Status)
+	}
+
+	return resp, nil
+}

--- a/modules/covid/client.go
+++ b/modules/covid/client.go
@@ -10,25 +10,19 @@ import (
 
 // LatestCases queries the /latest endpoint
 func LatestCases() (*Latest, error) {
-	// TODO: figure out the pointer logic here
-	latest := &Latest{}
-
 	resp, err := covidAPIRequest("latest")
 	if err != nil {
-		// TODO: figure out the pointer logic here
-		return latest, err
+		return nil, err
 	}
 
+	var latest Latest
 	err = utils.ParseJSON(&latest, resp.Body)
 	if err != nil {
-		// TODO: figure out the pointer logic here
-		return latest, err
+		return nil, err
 	}
-	// TODO: figure out the pointer logic here
-	return latest, nil
-}
 
-/* -------------------- Unexported Functions -------------------- */
+	return &latest, nil
+}
 
 var (
 	covidTrackerAPIURL = &url.URL{Scheme: "https", Host: "coronavirus-tracker-api.herokuapp.com", Path: "/v2/"}

--- a/modules/covid/client.go
+++ b/modules/covid/client.go
@@ -1,6 +1,7 @@
 package covid
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/wtfutil/wtf/utils"
@@ -12,6 +13,9 @@ const covidTrackerAPIURL = "https://coronavirus-tracker-api.herokuapp.com/v2/"
 func LatestCases() (*Cases, error) {
 	latestURL := covidTrackerAPIURL + "latest"
 	resp, err := http.Get(latestURL)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf(resp.Status)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -30,6 +34,9 @@ func LatestCases() (*Cases, error) {
 func (widget *Widget) LatestCountryCases(country string) (*CountryCases, error) {
 	countryURL := covidTrackerAPIURL + "locations?source=jhu&country_code=" + widget.settings.country
 	resp, err := http.Get(countryURL)
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf(resp.Status)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/modules/covid/client.go
+++ b/modules/covid/client.go
@@ -31,7 +31,7 @@ func LatestCases() (*Cases, error) {
 }
 
 // LatestCountryCases queries the /locations endpoint, takes a query parameter: the country code
-func (widget *Widget) LatestCountryCases(country string) (*CountryCases, error) {
+func (widget *Widget) LatestCountryCases(country string) (*Cases, error) {
 	countryURL := covidTrackerAPIURL + "locations?source=jhu&country_code=" + widget.settings.country
 	resp, err := http.Get(countryURL)
 	if resp.StatusCode != 200 {
@@ -42,7 +42,7 @@ func (widget *Widget) LatestCountryCases(country string) (*CountryCases, error) 
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	var latestCountryCases CountryCases
+	var latestCountryCases Cases
 	err = utils.ParseJSON(&latestCountryCases, resp.Body)
 	if err != nil {
 		return nil, err

--- a/modules/covid/client.go
+++ b/modules/covid/client.go
@@ -31,22 +31,28 @@ func LatestCases() (*Cases, error) {
 }
 
 // LatestCountryCases queries the /locations endpoint, takes a query parameter: the country code
-func (widget *Widget) LatestCountryCases(country string) (*Cases, error) {
-	countryURL := covidTrackerAPIURL + "locations?source=jhu&country_code=" + widget.settings.country
-	resp, err := http.Get(countryURL)
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf(resp.Status)
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
+func (widget *Widget) LatestCountryCases(countriesStats []interface{}) ([]*Cases, error) {
+	countriesCovidData := []*Cases{}
+	for _, name := range countriesStats {
+		countryURL := covidTrackerAPIURL + "locations?source=jhu&country_code=" + name.(string)
+		resp, err := http.Get(countryURL)
+		if resp.StatusCode != 200 {
+			return nil, fmt.Errorf(resp.Status)
+		}
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
 
-	var latestCountryCases Cases
-	err = utils.ParseJSON(&latestCountryCases, resp.Body)
-	if err != nil {
-		return nil, err
+		var latestCountryCases Cases
+		err = utils.ParseJSON(&latestCountryCases, resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		// add stats for each country to the slice
+		countriesCovidData = append(countriesCovidData, &latestCountryCases)
+
 	}
 
-	return &latestCountryCases, nil
+	return countriesCovidData, nil
 }

--- a/modules/covid/client_test.go
+++ b/modules/covid/client_test.go
@@ -1,0 +1,15 @@
+package covid
+
+import (
+	"testing"
+)
+
+func TestLatestCases(t *testing.T) {
+	latestCasesToAssert, err := LatestCases()
+	if err != nil {
+		t.Error("LatestCases() returned an error")
+	}
+	if latestCasesToAssert.Latest.Confirmed == 0 {
+		t.Error("LatestCases() should return a non 0 integer")
+	}
+}

--- a/modules/covid/client_test.go
+++ b/modules/covid/client_test.go
@@ -13,3 +13,19 @@ func TestLatestCases(t *testing.T) {
 		t.Error("LatestCases() should return a non 0 integer")
 	}
 }
+
+func (widget *Widget) TestCountryCases(t *testing.T) {
+	countryList := []string{"US", "FR"}
+	c := make([]interface{}, len(countryList))
+	for i, v := range countryList {
+		c[i] = v
+	}
+	latestCountryCasesToAssert, err := widget.LatestCountryCases(c)
+	if err != nil {
+		t.Error("LatestCountryCases() returned an error")
+	}
+	if len(latestCountryCasesToAssert) == 0 {
+		t.Error("LatestCountryCases() should not be empty")
+	}
+
+}

--- a/modules/covid/settings.go
+++ b/modules/covid/settings.go
@@ -14,7 +14,7 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	countries []interface{} `help:"Country (code) from which to retrieve stats."`
+	countries []interface{} `help:"Countries (codes) from which to retrieve stats."`
 }
 
 // NewSettingsFromYAML returns the settings from the config yaml file

--- a/modules/covid/settings.go
+++ b/modules/covid/settings.go
@@ -1,0 +1,25 @@
+package covid
+
+import (
+	"github.com/olebedev/config"
+	"github.com/wtfutil/wtf/cfg"
+)
+
+const (
+	defaultFocusable = false
+	defaultTitle     = "Covid"
+)
+
+
+type Settings struct {
+	*cfg.Common
+}
+
+func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
+
+	settings := Settings{
+		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+	}
+
+	return &settings
+}

--- a/modules/covid/settings.go
+++ b/modules/covid/settings.go
@@ -13,6 +13,8 @@ const (
 // Settings is the struct for this module's settings
 type Settings struct {
 	*cfg.Common
+
+	country string `help:"Country (code) from which to retrieve stats."`
 }
 
 // NewSettingsFromYAML returns the settings from the config yaml file
@@ -20,6 +22,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
+
+		country: ymlConfig.UString("country"),
 	}
 
 	return &settings

--- a/modules/covid/settings.go
+++ b/modules/covid/settings.go
@@ -7,14 +7,15 @@ import (
 
 const (
 	defaultFocusable = false
-	defaultTitle     = "Covid"
+	defaultTitle     = "Covid tracker"
 )
 
-
+// Settings is the struct for this module's settings
 type Settings struct {
 	*cfg.Common
 }
 
+// NewSettingsFromYAML returns the settings from the config yaml file
 func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *config.Config) *Settings {
 
 	settings := Settings{

--- a/modules/covid/settings.go
+++ b/modules/covid/settings.go
@@ -14,7 +14,7 @@ const (
 type Settings struct {
 	*cfg.Common
 
-	country string `help:"Country (code) from which to retrieve stats."`
+	countries []interface{} `help:"Country (code) from which to retrieve stats."`
 }
 
 // NewSettingsFromYAML returns the settings from the config yaml file
@@ -23,7 +23,8 @@ func NewSettingsFromYAML(name string, ymlConfig *config.Config, globalConfig *co
 	settings := Settings{
 		Common: cfg.NewCommonSettingsFromModule(name, defaultTitle, defaultFocusable, ymlConfig, globalConfig),
 
-		country: ymlConfig.UString("country"),
+		// List of countries to retrieve stats from
+		countries: ymlConfig.UList("countries"),
 	}
 
 	return &settings

--- a/modules/covid/widget.go
+++ b/modules/covid/widget.go
@@ -11,8 +11,6 @@ import (
 type Widget struct {
 	view.TextWidget
 
-	// CountriesStats []*Latest
-
 	settings *Settings
 	err      error
 }
@@ -24,6 +22,8 @@ func NewWidget(app *tview.Application, settings *Settings) *Widget {
 
 		settings: settings,
 	}
+
+	widget.View.SetScrollable(true)
 
 	return widget
 }

--- a/modules/covid/widget.go
+++ b/modules/covid/widget.go
@@ -2,30 +2,31 @@ package covid
 
 import (
 	"fmt"
+
 	"github.com/rivo/tview"
 	"github.com/wtfutil/wtf/view"
-
 )
 
+// Widget is the struct that defines this module widget
 type Widget struct {
 	view.TextWidget
 
-	settings  *Settings
-	err       error
+	settings *Settings
+	err      error
 }
 
+// NewWidget creates a new widget for this module
 func NewWidget(app *tview.Application, settings *Settings) *Widget {
-	widget := Widget{
+	widget := &Widget{
 		TextWidget: view.NewTextWidget(app, nil, settings.Common),
 
 		settings: settings,
 	}
 
-	return &widget
+	return widget
 }
 
-/* -------------------- Exported Functions -------------------- */
-
+// Refresh checks if this module widget is disabled
 func (widget *Widget) Refresh() {
 	if widget.Disabled() {
 		return
@@ -34,7 +35,10 @@ func (widget *Widget) Refresh() {
 	widget.Redraw(widget.content)
 }
 
-/* -------------------- Unexported Functions -------------------- */
+// Render renders this module widget
+func (widget *Widget) Render() {
+	widget.Redraw(widget.content)
+}
 
 func (widget *Widget) content() (string, string, bool) {
 	title := defaultTitle

--- a/modules/covid/widget.go
+++ b/modules/covid/widget.go
@@ -58,7 +58,7 @@ func (widget *Widget) content() (string, string, bool) {
 		covidStats += fmt.Sprintf("%s: %d\n", "Confirmed", cases.Latest.Confirmed)
 		covidStats += fmt.Sprintf("%s: %d\n", "Deaths", cases.Latest.Confirmed)
 	}
-	// Retrieve country stats if the country code is set in the config
+	// Retrieve country stats if country codes are set in the config
 	if len(widget.settings.countries) > 0 {
 		countryCases, err := widget.LatestCountryCases(widget.settings.countries)
 		if err != nil {
@@ -71,5 +71,6 @@ func (widget *Widget) content() (string, string, bool) {
 			}
 		}
 	}
+
 	return title, covidStats, true
 }

--- a/modules/covid/widget.go
+++ b/modules/covid/widget.go
@@ -46,15 +46,28 @@ func (widget *Widget) content() (string, string, bool) {
 		title = widget.CommonSettings().Title
 	}
 
-	latest, err := LatestCases()
-	var str string
+	cases, err := LatestCases()
+	var covidInfo string
 	if err != nil {
 		widget.err = err
 	} else {
-		str = fmt.Sprintf("[%s]Covid[white]\n", widget.settings.Colors.Subheading)
-		str += fmt.Sprintf("%s: %d\n", "Confirmed", latest.Confirmed)
-		str += fmt.Sprintf("%s: %d\n", "Deaths", latest.Deaths)
-		str += fmt.Sprintf("%s: %d\n", "Recovered", latest.Recovered)
+		covidInfo = fmt.Sprintf("[%s]Gobal[white]\n", widget.settings.Colors.Subheading)
+		covidInfo += fmt.Sprintf("%s: %d\n", "Confirmed", cases.Latest.Confirmed)
+		covidInfo += fmt.Sprintf("%s: %d\n", "Deaths", cases.Latest.Confirmed)
+		covidInfo += fmt.Sprintf("%s: %d\n", "Recovered", cases.Latest.Recovered)
 	}
-	return title, str, true
+	// Retrieve country stats if the country code is set in the config
+	if widget.settings.country != "" {
+		countryCases, err := widget.LatestCountryCases(widget.settings.country)
+		if err != nil {
+			widget.err = err
+		} else {
+			covidInfo += "\n"
+			covidInfo += fmt.Sprintf("[%s]Country stats[white]: %s\n", widget.settings.Colors.Subheading, widget.settings.country)
+			covidInfo += fmt.Sprintf("%s: %d\n", "Confirmed", countryCases.LatestCountryCases.Confirmed)
+			covidInfo += fmt.Sprintf("%s: %d\n", "Deaths", countryCases.LatestCountryCases.Deaths)
+			covidInfo += fmt.Sprintf("%s: %d\n", "Recovered", countryCases.LatestCountryCases.Recovered)
+		}
+	}
+	return title, covidInfo, true
 }

--- a/modules/covid/widget.go
+++ b/modules/covid/widget.go
@@ -11,6 +11,8 @@ import (
 type Widget struct {
 	view.TextWidget
 
+	// CountriesStats []*Latest
+
 	settings *Settings
 	err      error
 }
@@ -57,15 +59,16 @@ func (widget *Widget) content() (string, string, bool) {
 		covidStats += fmt.Sprintf("%s: %d\n", "Deaths", cases.Latest.Confirmed)
 	}
 	// Retrieve country stats if the country code is set in the config
-	if widget.settings.country != "" {
-		countryCases, err := widget.LatestCountryCases(widget.settings.country)
+	if len(widget.settings.countries) > 0 {
+		countryCases, err := widget.LatestCountryCases(widget.settings.countries)
 		if err != nil {
 			widget.err = err
 		} else {
-			covidStats += "\n"
-			covidStats += fmt.Sprintf("[%s]Country stats[white]: %s\n", widget.settings.Colors.Subheading, widget.settings.country)
-			covidStats += fmt.Sprintf("%s: %d\n", "Confirmed", countryCases.Latest.Confirmed)
-			covidStats += fmt.Sprintf("%s: %d\n", "Deaths", countryCases.Latest.Deaths)
+			for i, name := range countryCases {
+				covidStats += fmt.Sprintf("[%s]Country[white]: %s\n", widget.settings.Colors.Subheading, widget.settings.countries[i])
+				covidStats += fmt.Sprintf("%s: %d\n", "Confirmed", name.Latest.Confirmed)
+				covidStats += fmt.Sprintf("%s: %d\n", "Deaths", name.Latest.Deaths)
+			}
 		}
 	}
 	return title, covidStats, true

--- a/modules/covid/widget.go
+++ b/modules/covid/widget.go
@@ -1,0 +1,56 @@
+package covid
+
+import (
+	"fmt"
+	"github.com/rivo/tview"
+	"github.com/wtfutil/wtf/view"
+
+)
+
+type Widget struct {
+	view.TextWidget
+
+	settings  *Settings
+	err       error
+}
+
+func NewWidget(app *tview.Application, settings *Settings) *Widget {
+	widget := Widget{
+		TextWidget: view.NewTextWidget(app, nil, settings.Common),
+
+		settings: settings,
+	}
+
+	return &widget
+}
+
+/* -------------------- Exported Functions -------------------- */
+
+func (widget *Widget) Refresh() {
+	if widget.Disabled() {
+		return
+	}
+
+	widget.Redraw(widget.content)
+}
+
+/* -------------------- Unexported Functions -------------------- */
+
+func (widget *Widget) content() (string, string, bool) {
+	title := defaultTitle
+	if widget.CommonSettings().Title != "" {
+		title = widget.CommonSettings().Title
+	}
+
+	latest, err := LatestCases()
+	var str string
+	if err != nil {
+		widget.err = err
+	} else {
+		str = fmt.Sprintf("[%s]Covid[white]\n", widget.settings.Colors.Subheading)
+		str += fmt.Sprintf("%s: %d\n", "Confirmed", latest.Confirmed)
+		str += fmt.Sprintf("%s: %d\n", "Deaths", latest.Deaths)
+		str += fmt.Sprintf("%s: %d\n", "Recovered", latest.Recovered)
+	}
+	return title, str, true
+}

--- a/modules/covid/widget.go
+++ b/modules/covid/widget.go
@@ -47,13 +47,14 @@ func (widget *Widget) content() (string, string, bool) {
 	}
 
 	cases, err := LatestCases()
-	var covidInfo string
+	var covidStats string
 	if err != nil {
 		widget.err = err
 	} else {
-		covidInfo = fmt.Sprintf("[%s]Gobal[white]\n", widget.settings.Colors.Subheading)
-		covidInfo += fmt.Sprintf("%s: %d\n", "Confirmed", cases.Latest.Confirmed)
-		covidInfo += fmt.Sprintf("%s: %d\n", "Deaths", cases.Latest.Confirmed)
+		// Display global stats
+		covidStats = fmt.Sprintf("[%s]Gobal[white]\n", widget.settings.Colors.Subheading)
+		covidStats += fmt.Sprintf("%s: %d\n", "Confirmed", cases.Latest.Confirmed)
+		covidStats += fmt.Sprintf("%s: %d\n", "Deaths", cases.Latest.Confirmed)
 	}
 	// Retrieve country stats if the country code is set in the config
 	if widget.settings.country != "" {
@@ -61,11 +62,11 @@ func (widget *Widget) content() (string, string, bool) {
 		if err != nil {
 			widget.err = err
 		} else {
-			covidInfo += "\n"
-			covidInfo += fmt.Sprintf("[%s]Country stats[white]: %s\n", widget.settings.Colors.Subheading, widget.settings.country)
-			covidInfo += fmt.Sprintf("%s: %d\n", "Confirmed", countryCases.LatestCountryCases.Confirmed)
-			covidInfo += fmt.Sprintf("%s: %d\n", "Deaths", countryCases.LatestCountryCases.Deaths)
+			covidStats += "\n"
+			covidStats += fmt.Sprintf("[%s]Country stats[white]: %s\n", widget.settings.Colors.Subheading, widget.settings.country)
+			covidStats += fmt.Sprintf("%s: %d\n", "Confirmed", countryCases.Latest.Confirmed)
+			covidStats += fmt.Sprintf("%s: %d\n", "Deaths", countryCases.Latest.Deaths)
 		}
 	}
-	return title, covidInfo, true
+	return title, covidStats, true
 }

--- a/modules/covid/widget.go
+++ b/modules/covid/widget.go
@@ -54,7 +54,6 @@ func (widget *Widget) content() (string, string, bool) {
 		covidInfo = fmt.Sprintf("[%s]Gobal[white]\n", widget.settings.Colors.Subheading)
 		covidInfo += fmt.Sprintf("%s: %d\n", "Confirmed", cases.Latest.Confirmed)
 		covidInfo += fmt.Sprintf("%s: %d\n", "Deaths", cases.Latest.Confirmed)
-		covidInfo += fmt.Sprintf("%s: %d\n", "Recovered", cases.Latest.Recovered)
 	}
 	// Retrieve country stats if the country code is set in the config
 	if widget.settings.country != "" {
@@ -66,7 +65,6 @@ func (widget *Widget) content() (string, string, bool) {
 			covidInfo += fmt.Sprintf("[%s]Country stats[white]: %s\n", widget.settings.Colors.Subheading, widget.settings.country)
 			covidInfo += fmt.Sprintf("%s: %d\n", "Confirmed", countryCases.LatestCountryCases.Confirmed)
 			covidInfo += fmt.Sprintf("%s: %d\n", "Deaths", countryCases.LatestCountryCases.Deaths)
-			covidInfo += fmt.Sprintf("%s: %d\n", "Recovered", countryCases.LatestCountryCases.Recovered)
 		}
 	}
 	return title, covidInfo, true


### PR DESCRIPTION
This is a covid tracker module using this API: https://coronavirus-tracker-api.herokuapp.com/#/v2/. 

Config would look like:

```yaml
covid:
  enabled: true
  countries:
    - "FR"
    - "US"
    - "DE"
    - ...
   refreshInterval: 120
   position:
        ...
```

And the result would look like:

```
┌─────────────────────── Covid tracker ────────────────────────┐
│  ││Gobal
│  ││Confirmed: ...
│  ││Deaths: ...
│  ││Country: FR
│  ││Confirmed: ...
│  ││Deaths: ...
│  ││Country: US
│  ││Confirmed: ...
│  ││Deaths: ...
```

Remaining issue: the third country stats do not appear here, I tried setting `widget.View.SetScrollable` to true but that didn't seem to change anything. Setting it to draft for the time being but initial feedback welcome.
